### PR TITLE
isRequestAction: Don't treat Error objects as request actions. Fixes #132

### DIFF
--- a/packages/redux-saga-requests/src/helpers.js
+++ b/packages/redux-saga-requests/src/helpers.js
@@ -3,7 +3,11 @@ export const getActionPayload = action =>
 
 export const isRequestAction = action => {
   const actionPayload = getActionPayload(action);
-  return !!actionPayload.request && !actionPayload.response;
+  return (
+    !!actionPayload.request &&
+    !actionPayload.response &&
+    !(actionPayload instanceof Error)
+  );
 };
 
 export const mapRequest = (request, callback) =>


### PR DESCRIPTION
See #132