### PR TITLE
Fix fail when some action has a null payload

### DIFF
--- a/packages/redux-saga-requests/src/helpers.js
+++ b/packages/redux-saga-requests/src/helpers.js
@@ -4,6 +4,7 @@ export const getActionPayload = action =>
 export const isRequestAction = action => {
   const actionPayload = getActionPayload(action);
   return (
+    !!actionPayload &&
     !!actionPayload.request &&
     !actionPayload.response &&
     !(actionPayload instanceof Error)


### PR DESCRIPTION
I've got an issue `actionPayload is null` in `redux-saga-requests` middleware when an action of [`redux-form`](https://github.com/erikras/redux-form) to set a field value to `null` is dispatched 

In this pull request I fix this issue.