### PR TITLE
#250 support specifying actionType for operation reducers

### DIFF
--- a/packages/redux-saga-requests/src/reducers.js
+++ b/packages/redux-saga-requests/src/reducers.js
@@ -112,6 +112,12 @@ export const createRequestsReducer = (globalConfig = {}) => (
     shouldResetForAction = (action) => normalizedResetActions.includes(action.type);
   }
 
+  const operationActionTypeMap = operations && Object.entries(operations).reduce((memo, [k, v]) => {
+    const actionType = v.hasOwnProperty('actionType') ? v.actionType : k;
+    memo[actionType] = v;
+    return memo;
+  }, {});
+
   return (state, action) => {
     let nextState =
       state === undefined ? getInitialState(state, reducer, config) : state;
@@ -123,8 +129,8 @@ export const createRequestsReducer = (globalConfig = {}) => (
       };
     }
 
-    if (operations && action.type in operations) {
-      const operationConfig = operations[action.type];
+    if (operations && action.type in operationActionTypeMap) {
+      const operationConfig = operationActionTypeMap[action.type];
 
       return {
         ...nextState,
@@ -158,10 +164,10 @@ export const createRequestsReducer = (globalConfig = {}) => (
     if (
       operations &&
       isResponseAction(action) &&
-      getRequestActionFromResponse(action).type in operations
+      getRequestActionFromResponse(action).type in operationActionTypeMap
     ) {
       const requestAction = getRequestActionFromResponse(action);
-      const operationConfig = operations[requestAction.type];
+      const operationConfig = operationActionTypeMap[requestAction.type];
       const {
         [requestAction.type]: currentOperation,
         ...otherOperations


### PR DESCRIPTION
Resolves #250 

Let me know if this interests you and I can add some unit tests. In terms of that issue example, this would look like

```js
// Call to run set feature saga
const setFeaturesAction = createAction(`set ${type}`);

const _setFeaturesAction = createAction(`set ${type} internal`, ({ map, [type]: features }) => {
  return {
    request: {
      url: '/v2/maps/operations/',
      method: 'post',
      data: formatRPCCall(`set${typeCapitalized}`, {
        map_id: map.id,
        features,
      })
    },
  };
}, ({ map, [type]: features }) => ({ map, features }));

// Get some stuff from state then run _setFeaturesAction.
const setFeaturesSaga = function* ({ payload }) {
  const { map } = yield select(state.maps);
  return yield put({ map, ...payload });
};

const reducer = requestsReducer({
  actionType: getFeaturesAction,
  // stuff and things...


  operations: {
    [setFeaturesAction]: {
      actionType: _setFeaturesAction.getType()
    },
  }
}, baseReducer);


// User dispatches
function mapStateToProps(state) {
  return {
    data: state.data,
    operation: state.operations.setFeaturesAction
  };
}

function mapDispatchToProps(dispatch) {
  return {
    runOp: () => {
      dispatch(setFeaturesAction)
    }
  }
}

```