### PR TITLE
[redux-saga-requests-graphql]Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string

### DIFF
--- a/packages/redux-saga-requests-graphql/types/index.d.ts
+++ b/packages/redux-saga-requests-graphql/types/index.d.ts
@@ -6,4 +6,7 @@ interface GraphqlDriverConfig {
 
 export const createDriver: (config: GraphqlDriverConfig) => Driver;
 
-export const gql: (query: string | TemplateStringsArray) => string;
+export const gql: (
+  query: TemplateStringsArray,
+  ...args: (string | number)[]
+) => string;

--- a/packages/redux-saga-requests-graphql/types/index.d.ts
+++ b/packages/redux-saga-requests-graphql/types/index.d.ts
@@ -6,4 +6,4 @@ interface GraphqlDriverConfig {
 
 export const createDriver: (config: GraphqlDriverConfig) => Driver;
 
-export const gql: (query: string) => string;
+export const gql: (query: string | TemplateStringsArray) => string;


### PR DESCRIPTION
Closes #309

Typescript seems to be crying when I try to use "gql" from "redux-saga-requests-graphql"
Can be resolved by adding "TemplateStringsArray" as a possible type for "gql" arguments.
Pull request in progress

btw, your lib rocks

```
ERROR in /<<workspace>>/actions.tsx(7,15):
7:15 Argument of type 'TemplateStringsArray' is not assignable to parameter of type 'string'.
     5 |   type: anAction,
     6 |   request: {
  >  7 |     query: gql`
       |               ^
     8 |       {
     9 |         a request
```