### PR TITLE
Add mutation data to requests reducer

### DIFF
--- a/docusaurus/docs/api-reference/get-mutation.md
+++ b/docusaurus/docs/api-reference/get-mutation.md
@@ -10,6 +10,7 @@ import { getMutation } from '@redux-requests/core';
 
 const deleteBookMutation = getMutation(state, { type: 'DELETE_BOOK' });
 /* for example {
+  data: null,
   loading: false,
   error: null,
   pending: 0 // number of pending requests
@@ -18,4 +19,4 @@ const deleteBookMutation = getMutation(state, { type: 'DELETE_BOOK' });
 } */
 ```
 
-It accept `type` and optionally `requestKey` props, which work like for queries.
+It accepts `type` and optionally `requestKey` props, which work like for queries.

--- a/packages/redux-requests-react/types/index.d.spec.tsx
+++ b/packages/redux-requests-react/types/index.d.spec.tsx
@@ -145,11 +145,12 @@ function BasicMutation() {
   );
 }
 
-function MutationComponent({ mutation, extra }: { mutation: MutationState, extra: any }) {
+function MutationComponent({ mutation, extra }: { mutation: MutationState<number>, extra: any }) {
   return (
     <div>
       {mutation.loading && 'loading'}
       {mutation.error}
+      {mutation.data}
       {extra}
     </div>
   );
@@ -170,6 +171,7 @@ function MutationWithSelector() {
   return (
     <Mutation
       selector={state => ({
+        data: null,
         error: null,
         loading: false,
         pending: 1,

--- a/packages/redux-requests-react/types/index.d.ts
+++ b/packages/redux-requests-react/types/index.d.ts
@@ -49,21 +49,23 @@ export class Query<QueryStateData = any, CustomComponentProps = {}> extends Reac
   QueryProps<QueryStateData, CustomComponentProps>
 > {}
 
-interface MutationCustomComponentProps {
-  mutation: MutationState;
+interface MutationCustomComponentProps<MutationStateData = any> {
+  mutation: MutationState<MutationStateData>;
   [extraProperty: string]: any;
 }
 
-interface MutationProps<CustomComponentProps> {
+interface MutationProps<MutationStateData, CustomComponentProps> {
   type?: string | ((...params: any[]) => RequestAction);
   requestKey?: string;
-  selector?: (state: any) => MutationState;
-  children?: (mutation: MutationState) => React.ReactNode;
+  selector?: (state: any) => MutationState<MutationStateData>;
+  children?: (mutation: MutationState<MutationStateData>) => React.ReactNode;
   component?: CustomComponentProps extends MutationCustomComponentProps ? React.ComponentType<CustomComponentProps> : never;
   [extraProperty: string]: any;
 }
 
-export class Mutation<CustomComponentProps = {}> extends React.Component<MutationProps<CustomComponentProps>> {}
+export class Mutation<MutationStateData = any, CustomComponentProps = {}> extends React.Component<
+  MutationProps<MutationStateData, CustomComponentProps>
+> {}
 
 interface RequestCreator<QueryStateData = any> {
   (...args: any[]): RequestAction<any, QueryStateData>;
@@ -119,7 +121,7 @@ export function useMutation<
   autoReset?: boolean;
   throwError?: boolean;
   suspense?: boolean;
-}): MutationState & {
+}): MutationState<Data> & {
   mutate: () => Promise<{
     data?: QueryState<
       Data extends undefined ? GetQueryStateData<MutationCreator> : Data

--- a/packages/redux-requests/src/actions.js
+++ b/packages/redux-requests/src/actions.js
@@ -69,6 +69,9 @@ export const getActionPayload = action =>
 export const getResponseFromSuccessAction = action =>
   action.payload ? action.payload : action.response;
 
+export const getDataFromResponseAction = action =>
+  action.payload ? action.payload.data : action.response.data;
+
 export const isRequestAction = action => {
   const actionPayload = getActionPayload(action);
 

--- a/packages/redux-requests/src/reducers/mutations-reducer.js
+++ b/packages/redux-requests/src/reducers/mutations-reducer.js
@@ -1,8 +1,10 @@
 import {
-  isErrorAction,
-  isAbortAction,
-  isResponseAction,
+  getDataFromResponseAction,
   getRequestActionFromResponse,
+  isAbortAction,
+  isErrorAction,
+  isResponseAction,
+  isSuccessAction,
 } from '../actions';
 
 export default (state, action) => {
@@ -13,6 +15,7 @@ export default (state, action) => {
     return {
       ...state,
       [mutationType]: {
+        data: null,
         error: null,
         pending: (state[mutationType] ? state[mutationType].pending : 0) + 1,
         ref: state[mutationType] ? state[mutationType].ref : {},
@@ -25,10 +28,23 @@ export default (state, action) => {
     requestAction.type +
     (action.meta?.requestKey ? action.meta.requestKey : '');
 
+  if (isSuccessAction(action)) {
+    return {
+      ...state,
+      [mutationType]: {
+        data: getDataFromResponseAction(action),
+        error: null,
+        pending: state[mutationType].pending - 1,
+        ref: state[mutationType].ref,
+      }
+    }
+  }
+
   if (isErrorAction(action)) {
     return {
       ...state,
       [mutationType]: {
+        data: null,
         error: action.payload ? action.payload : action.error,
         pending: state[mutationType].pending - 1,
         ref: state[mutationType].ref,
@@ -47,6 +63,7 @@ export default (state, action) => {
   return {
     ...state,
     [mutationType]: {
+      data: null,
       error: null,
       pending: state[mutationType].pending - 1,
       ref: state[mutationType].ref,

--- a/packages/redux-requests/src/reducers/queries-reducer.js
+++ b/packages/redux-requests/src/reducers/queries-reducer.js
@@ -4,6 +4,7 @@ import {
   error,
   abort,
   isResponseAction,
+  getDataFromResponseAction,
   getRequestActionFromResponse,
   isErrorAction,
   isSuccessAction,
@@ -22,9 +23,6 @@ const getInitialQuery = normalized => ({
   normalized,
   usedKeys: normalized ? {} : null,
 });
-
-const getDataFromResponseAction = action =>
-  action.payload ? action.payload.data : action.response.data;
 
 const shouldBeNormalized = (action, config) =>
   action.meta?.normalize !== undefined

--- a/packages/redux-requests/src/reducers/requests-reducer.spec.js
+++ b/packages/redux-requests/src/reducers/requests-reducer.spec.js
@@ -260,6 +260,7 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: null,
             error: null,
             pending: 1,
             ref: {},
@@ -287,6 +288,7 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: null,
             error: 'error',
             pending: 0,
             ref: {},
@@ -314,6 +316,7 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: null,
             error: null,
             pending: 1,
             ref: {},
@@ -344,6 +347,7 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
@@ -381,11 +385,13 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG: {
+            data: null,
             error: null,
             pending: 1,
             ref: {},
@@ -416,11 +422,13 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG: {
+            data: 'data2',
             error: null,
             pending: 0,
             ref: {},
@@ -460,16 +468,19 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG: {
+            data: 'data2',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG_WITH_REQUEST_KEY1: {
+            data: null,
             error: null,
             pending: 2,
             ref: {},
@@ -504,16 +515,19 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG: {
+            data: 'data2',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG_WITH_REQUEST_KEY1: {
+            data: 'data3',
             error: null,
             pending: 1,
             ref: {},
@@ -548,16 +562,19 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG: {
+            data: 'data2',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG_WITH_REQUEST_KEY1: {
+            data: 'data3',
             error: null,
             pending: 0,
             ref: {},
@@ -601,21 +618,25 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG: {
+            data: 'data2',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG_WITH_REQUEST_KEY1: {
+            data: 'data3',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_OPTIMISTIC_UPDATE: {
+            data: null,
             error: null,
             pending: 1,
             ref: {},
@@ -648,21 +669,25 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG: {
+            data: 'data2',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG_WITH_REQUEST_KEY1: {
+            data: 'data3',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_OPTIMISTIC_UPDATE: {
+            data: 'data4',
             error: null,
             pending: 0,
             ref: {},
@@ -697,21 +722,25 @@ describe('reducers', () => {
         },
         mutations: {
           MUTATION_WITHOUT_CONFIG: {
+            data: 'data',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG: {
+            data: 'data2',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_CONFIG_WITH_REQUEST_KEY1: {
+            data: 'data3',
             error: null,
             pending: 0,
             ref: {},
           },
           MUTATION_WITH_OPTIMISTIC_UPDATE: {
+            data: null,
             error: 'error',
             pending: 0,
             ref: {},

--- a/packages/redux-requests/src/reducers/requests-reset-reducer.js
+++ b/packages/redux-requests/src/reducers/requests-reset-reducer.js
@@ -27,6 +27,7 @@ const resetMutation = mutation =>
     ? undefined
     : {
         ...mutation,
+        data: null,
         error: null,
       };
 

--- a/packages/redux-requests/src/reducers/requests-reset-reducer.spec.js
+++ b/packages/redux-requests/src/reducers/requests-reset-reducer.spec.js
@@ -32,7 +32,8 @@ describe('reducers', () => {
               },
             },
             mutations: {
-              MUTATION: { error: 'error', pending: 1 },
+              MUTATION: { error: 'error', pending: 1, data: null },
+              MUTATION2: { error: null, pending: 1, data: "success" }
             },
             cache: { QUERY2: {} },
             downloadProgress: {},
@@ -60,7 +61,8 @@ describe('reducers', () => {
           },
         },
         mutations: {
-          MUTATION: { error: null, pending: 1 },
+          MUTATION: { error: null, pending: 1, data: null },
+          MUTATION2: { error: null, pending: 1, data: null }
         },
         cache: {},
         downloadProgress: {},
@@ -99,9 +101,9 @@ describe('reducers', () => {
               },
             },
             mutations: {
-              MUTATION: { error: 'error', pending: 1 },
-              MUTATION2: { error: 'error', pending: 1 },
-              MUTATION3: { error: 'error', pending: 1 },
+              MUTATION: { error: 'error', pending: 1, data: null },
+              MUTATION2: { error: 'error', pending: 1, data: null },
+              MUTATION3: { error: null, pending: 1, data: 'data' },
             },
             downloadProgress: {},
             uploadProgress: {},
@@ -111,6 +113,7 @@ describe('reducers', () => {
             'QUERY',
             { requestType: 'QUERY', requestKey: '2' },
             { requestType: 'MUTATION', requestKey: '2' },
+            { requestType: 'MUTATION3', requestKey: '2' },
           ]),
         ),
       ).toEqual({
@@ -141,9 +144,9 @@ describe('reducers', () => {
           },
         },
         mutations: {
-          MUTATION: { error: 'error', pending: 1 },
-          MUTATION2: { error: null, pending: 1 },
-          MUTATION3: { error: 'error', pending: 1 },
+          MUTATION: { error: null, pending: 1, data: null },
+          MUTATION2: { error: 'error', pending: 1, data: null },
+          MUTATION3: { error: null, pending: 1, data: null },
         },
         cache: { QUERY3: {} },
         downloadProgress: {},

--- a/packages/redux-requests/types/index.d.spec.ts
+++ b/packages/redux-requests/types/index.d.spec.ts
@@ -115,6 +115,13 @@ getMutation({}, { type: 'Mutation', requestKey: '1' });
 const mutationSelector = getMutationSelector({ type: 'Mutation' });
 mutationSelector({});
 
+const mutation = getMutation<{ key: string }>({}, { type: 'Mutation' });
+mutation.data.key = '1';
+
+const mutationSelector2 = getMutationSelector<{ key: string }>({ type: 'Mutation' });
+const mutation2 = mutationSelector2({});
+mutation2.data.key = '1';
+
 isRequestAction({ type: 'ACTION' }) === true;
 isRequestActionQuery({ type: 'ACTION', request: { url: '/' } }) === true;
 isResponseAction({ type: 'ACTION', request: { url: '/' } }) === true;

--- a/packages/redux-requests/types/index.d.ts
+++ b/packages/redux-requests/types/index.d.ts
@@ -322,26 +322,27 @@ export function getQuerySelector<QueryStateData = any>(props: {
   defaultData?: any;
 }): (state: any) => QueryState<QueryStateData>;
 
-export interface MutationState {
+export interface MutationState<MutationStateData> {
+  data: MutationStateData;
+  error: any;
   pending: number;
   loading: boolean;
-  error: any;
   uploadProgress: number | null;
   downloadProgress: number | null;
 }
 
-export function getMutation(
+export function getMutation<MutationStateData = any>(
   state: any,
   props: {
     type: string | ((...params: any[]) => RequestAction);
     requestKey?: string;
   },
-): MutationState;
+): MutationState<MutationStateData>;
 
-export function getMutationSelector(props: {
+export function getMutationSelector<MutationStateData = any>(props: {
   type: string | ((...params: any[]) => RequestAction);
   requestKey?: string;
-}): (state: any) => MutationState;
+}): (state: any) => MutationState<MutationStateData>;
 
 export function getWebsocketState(): { pristine: boolean; connected: boolean };
 


### PR DESCRIPTION
# About

This pull request exposes mutation data in the requests reducer making `getMutation` and `getMutationSelector` functions more useful for side-effects like redirects:

For example:
```javascript
import { connect } from "react-redux";
import { getMutation } from "redux-requests/core";
import { Navigate } from "react-router-dom";

export function NewProductPage({ data, loading, error, onSubmit }) {
  if (data) {
    return <Navigate to={`/products/${data.id}`} />
  }
  return <ProductForm loading={loading} error={error} onSubmit={onSubmit} />
}

// action creator
const createProduct = ({ data }) => ({
  type: "CREATE_PRODUCT",
  request: {
    url: "/api/products/",
    method: "POST",
    data,
  }
});

const mapStateToProps = (state) => {
  const { loading, error, data } = getMutation(state, { type: "CREATE_PRODUCT" });
  return { loading, error, data };
}

const mapDispatchToProps = {
  onSubmit: createProduct
};

export default connect(mapStateToProps, mapDispatchToProps)(NewProductPage);
```

To do a redirect in `NewProductPage` component, the code must know the product id returned by the server. The response data is saved in the state for queries only making it hard to implement this behavior without hooks.

## Analogies
Many other popular libraries provide this functionality:

- react-query: https://react-query.tanstack.com/guides/mutations
- Apollo: https://www.apollographql.com/docs/react/data/mutations/

## Pitfalls
The PR affects TypeScript definitions in @redux-requests/react library changing generic types used for `MutationProps`, `MutationCustomComponentProps` and `Mutation` types. This may be considered as a breaking change since the first generic type represents `MutationState` data now similar to `QueryState`.